### PR TITLE
Fix broken package references on gatsby package.

### DIFF
--- a/packages/gatsby-starter-maker-ui/gatsby-config.js
+++ b/packages/gatsby-starter-maker-ui/gatsby-config.js
@@ -26,7 +26,7 @@ module.exports = {
         background_color: `#ffffff`,
         theme_color: false,
         display: `minimal-ui`,
-        icon: `src/assets/maker-ui.png`,
+        icon: `src/assets/elements-ui.png`,
       },
     },
   ],

--- a/packages/gatsby-starter-maker-ui/package.json
+++ b/packages/gatsby-starter-maker-ui/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@maker-ui/seo": "^0.4.3",
     "maker-ui": "^0.4.2",
     "gatsby": "^2.19.23",
     "gatsby-plugin-catch-links": "^2.1.26",

--- a/packages/gatsby-starter-maker-ui/src/components/Layout.js
+++ b/packages/gatsby-starter-maker-ui/src/components/Layout.js
@@ -7,8 +7,8 @@ import {
   Content,
   Main,
   Footer,
-  SEOProvider,
 } from 'maker-ui'
+import { SEOProvider } from '@maker-ui/seo'
 
 import options from '../config/options'
 import theme from '../config/theme'

--- a/packages/gatsby-starter-maker-ui/src/pages/index.js
+++ b/packages/gatsby-starter-maker-ui/src/pages/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, Heading } from 'theme-ui'
-import { SEO } from 'maker-ui'
+import { SEO } from '@maker-ui/seo'
 
 const Highlite = ({ fontSize = [17, 19], ...props }) => (
   <Box


### PR DESCRIPTION
Fix broken SEO package (now `@maker-ui/seo`) and `elements-ui.png` references on gatsby package.